### PR TITLE
Add bracket matching

### DIFF
--- a/languages/gleam/brackets.scm
+++ b/languages/gleam/brackets.scm
@@ -1,0 +1,4 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)


### PR DESCRIPTION
I noticed in vim mode I was unable to jump to matching brackets/parens using `%`. I found https://github.com/zed-industries/zed/issues/6702, where the solution was to update `brackets.scm`. 

This PR adds `brackets.scm` following those examples, which highlights bracket pairs when the cursor is over them and enables jumping between the pairs in vim.

docs: https://zed.dev/docs/extensions/languages#bracket-matching