### PR TITLE
Highlight echo as a keyword

### DIFF
--- a/languages/gleam/highlights.scm
+++ b/languages/gleam/highlights.scm
@@ -77,7 +77,7 @@
 ; TODO: when tree-sitter supports `#any-of?` in the Rust bindings,
 ; refactor this to use `#any-of?` rather than `#match?`
 ((identifier) @warning
- (#match? @warning "^(auto|delegate|derive|else|implement|macro|test|echo)$"))
+ (#match? @warning "^(auto|delegate|derive|else|implement|macro|test)$"))
 
 ; Keywords
 [
@@ -87,6 +87,7 @@
   "assert"
   "case"
   "const"
+  "echo"
   ; DEPRECATED: 'external' was removed in v0.30.
   "external"
   "fn"


### PR DESCRIPTION
Hello! `echo` is dropping in the next Gleam release, testing it in Zed I noticed `echo` is not highlighted as a keyword. This PR fixes that!