### PR TITLE
Use .zip extension when downloading Gleam on Windows

### DIFF
--- a/src/gleam.rs
+++ b/src/gleam.rs
@@ -76,13 +76,15 @@ impl GleamExtension {
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
-            let filetype = match platform {
-                zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
-                zed::Os::Windows => zed::DownloadedFileType::Zip,
-            };
-
-            zed::download_file(&asset.download_url, &version_dir, filetype)
-                .map_err(|e| format!("failed to download file: {e}"))?;
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                match platform {
+                    zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
+                    zed::Os::Windows => zed::DownloadedFileType::Zip,
+                },
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;

--- a/src/gleam.rs
+++ b/src/gleam.rs
@@ -43,7 +43,7 @@ impl GleamExtension {
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(
-            "gleam-{version}-{arch}-{os}.tar.gz",
+            "gleam-{version}-{arch}-{os}.{ext}",
             version = release.version,
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
@@ -54,6 +54,10 @@ impl GleamExtension {
                 zed::Os::Mac => "apple-darwin",
                 zed::Os::Linux => "unknown-linux-musl",
                 zed::Os::Windows => "pc-windows-msvc",
+            },
+            ext = match platform {
+                zed::Os::Mac | zed::Os::Linux => "tar.gz",
+                zed::Os::Windows => "zip",
             },
         );
 
@@ -72,12 +76,13 @@ impl GleamExtension {
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
-            zed::download_file(
-                &asset.download_url,
-                &version_dir,
-                zed::DownloadedFileType::GzipTar,
-            )
-            .map_err(|e| format!("failed to download file: {e}"))?;
+            let filetype = match platform {
+                zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
+                zed::Os::Windows => zed::DownloadedFileType::Zip,
+            };
+
+            zed::download_file(&asset.download_url, &version_dir, filetype)
+                .map_err(|e| format!("failed to download file: {e}"))?;
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;


### PR DESCRIPTION
Windows distributions of the gleam executable use a zipfile rather than a tarball; this PR enables the extension to download the binary successfully.

Since Windows support in Zed is a bit raw right now, I don't *think* this does anything unexpected but it's very difficult to test. Feedback welcome.