### PR TITLE
v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "zed_gleam"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "html_to_markdown",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_gleam"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "gleam"
 name = "Gleam"
 description = "Gleam support."
-version = "0.4.0"
+version = "0.5.0"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/gleam-lang/zed-gleam"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.5.0.

Changes:

- https://github.com/gleam-lang/zed-gleam/pull/13
  - Adds highlighting support for `assert` keyword in tests