### PR TITLE
Use more specific capture names for functions

### DIFF
--- a/languages/gleam/highlights.scm
+++ b/languages/gleam/highlights.scm
@@ -28,17 +28,17 @@
 (unqualified_import "type" (type_identifier) @type)
 (unqualified_import (type_identifier) @constructor)
 (function
-  name: (identifier) @function)
+  name: (identifier) @function.definition)
 (external_function
-  name: (identifier) @function)
+  name: (identifier) @function.definition)
 (function_parameter
   name: (identifier) @variable.parameter)
 ((function_call
-   function: (identifier) @function)
+   function: (identifier) @function.call)
  (#is-not? local))
 ((binary_expression
    operator: "|>"
-   right: (identifier) @function)
+   right: (identifier) @function.call)
  (#is-not? local))
 
 ; "Properties"


### PR DESCRIPTION
To enable theme to define separate colours on function definitions than on function calls. 

cf. https://github.com/tsimoshka/zed-theme-alabaster/issues/4#issuecomment-3048421714