### PR TITLE
Add comment language injections

### DIFF
--- a/languages/gleam/injections.scm
+++ b/languages/gleam/injections.scm
@@ -1,2 +1,8 @@
 ((comment) @content
   (#set! "language" "comment"))
+
+((statement_comment) @content
+  (#set! "language" "comment"))
+
+((module_comment) @content
+  (#set! "language" "comment"))


### PR DESCRIPTION
With the Comment extension installed, this will allow comments starting with TODO, FIXME, etc to be styled